### PR TITLE
Remove source of .bashrc

### DIFF
--- a/5.16/.sti/bin/assemble
+++ b/5.16/.sti/bin/assemble
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# For SCL enablement
-source .bashrc
-
 set -e
 
 echo "---> Installing application source"

--- a/5.16/.sti/bin/run
+++ b/5.16/.sti/bin/run
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# For SCL enablement
-source .bashrc
-
 set -e
 
 exec httpd -C 'Include /opt/openshift/httpd.conf' -D FOREGROUND


### PR DESCRIPTION
The sti base image will take care of it through BASH_ENV.

This depends on https://github.com/openshift/sti-base/pull/33