### PR TITLE
Remove unnecessary PATH modification

### DIFF
--- a/5.20/Dockerfile
+++ b/5.20/Dockerfile
@@ -6,8 +6,7 @@ MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 EXPOSE 8080
 
 # Image metadata
-ENV PERL_VERSION=5.20 \
-    PATH=$PATH:/opt/rh/rh-perl520/root/usr/local/bin
+ENV PERL_VERSION=5.20
 
 LABEL io.k8s.description="Platform for building and running Perl 5.20 applications" \
       io.k8s.display-name="Apache 2.4 with mod_perl/5.20" \

--- a/5.20/Dockerfile.rhel7
+++ b/5.20/Dockerfile.rhel7
@@ -6,8 +6,7 @@ MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 EXPOSE 8080
 
 # Image metadata
-ENV PERL_VERSION=5.20 \
-    PATH=$PATH:/opt/rh/rh-perl520/root/usr/local/bin
+ENV PERL_VERSION=5.20
 
 LABEL io.k8s.description="Platform for building and running Perl 5.20 applications" \
       io.k8s.display-name="Apache 2.4 with mod_perl/5.20" \


### PR DESCRIPTION
This removes unnecessary PATH modification. It's not needed because adding a collection path is properly handled by scl_enable script in perl 5.20 Dockerfile. The code was unintentionally  preserved while porting from 5.16.