### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/5.16/Dockerfile.rhel7
+++ b/5.16/Dockerfile.rhel7
@@ -1,8 +1,6 @@
 FROM openshift/base-rhel7
 
 # This image provides a Perl 5.16 environment you can use to run your Perl applications.
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 # Image metadata

--- a/5.20/Dockerfile.rhel7
+++ b/5.20/Dockerfile.rhel7
@@ -1,8 +1,6 @@
 FROM openshift/base-rhel7
 
 # This image provides a Perl 5.20 environment you can use to run your Perl applications.
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 # Image metadata


### PR DESCRIPTION
It is recommended not to use MAINTAINER in RHEL images.