### PR TITLE
support multiple namespaces for pushing

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,7 +13,8 @@ VERSION=$2
 
 DOCKERFILE_PATH=""
 BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-[0-9]*$//g')
-BASE_IMAGE_NAME="openshift/${BASE_DIR_NAME#sti-}"
+BASE_IMAGE_NAME="${BASE_DIR_NAME#sti-}"
+NAMESPACE="openshift/"
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT
@@ -48,7 +49,14 @@ function squash {
 dirs=${VERSION:-$VERSIONS}
 
 for dir in ${dirs}; do
-  IMAGE_NAME="${BASE_IMAGE_NAME}-${dir//./}-${OS}"
+  if [ "$dir" == "5.20" ]; then
+    if [ "${OS}" == "centos7" ]; then
+      NAMESPACE="centos/"
+    else
+      NAMESPACE="rhscl/"
+    fi
+  fi
+  IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
   if [[ -v TEST_MODE ]]; then
     IMAGE_NAME+="-candidate"
@@ -71,6 +79,5 @@ for dir in ${dirs}; do
       docker tag -f $IMAGE_NAME ${IMAGE_NAME%"-candidate"}
     fi
   fi
-
   popd > /dev/null
 done


### PR DESCRIPTION
RHSL-2.0-based images will have different namespace than the old "openshift". See mongodb commit:

commit 63f60041b941b6f9c942e32a03dd8c5c02fa4a0f
Author: Ben Parees <bparees@redhat.com>
Date:   Fri Sep 18 13:20:13 2015 -0400

    support multiple namespaces for pushing