### PR TITLE
Configure Apache to write access logs to stdout instead of file.

### DIFF
--- a/5.16/contrib/etc/httpdconf.sed
+++ b/5.16/contrib/etc/httpdconf.sed
@@ -4,4 +4,4 @@ s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
 s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
-s%CustomLog "logs/access_log"%CustomLog "/tmp/access_log"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%

--- a/5.20/contrib/etc/httpdconf.sed
+++ b/5.20/contrib/etc/httpdconf.sed
@@ -4,4 +4,4 @@ s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
 s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
-s%CustomLog "logs/access_log"%CustomLog "/tmp/access_log"%
+s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%


### PR DESCRIPTION
Copy the behavior of php images: https://github.com/openshift/sti-php/pull/64

PTAL @mfojtik @rhcarvalho

BTW, should we add the same Logs section as we have for PHP? Right now we don't have such section but IMHO it may be useful.