### PR TITLE
Fix executing script installed from CPAN

### DIFF
--- a/5.20/s2i/bin/run
+++ b/5.20/s2i/bin/run
@@ -2,6 +2,12 @@
 
 set -e
 
+# CPAN can install scripts. They should be available from mod_perl too.
+export PATH=${PATH}:/opt/app-root/src/extlib/bin
+# And we have to set Perl include path too because mod_perl's PerlSwitches
+# does not apply to them.
+export PERL5LIB=/opt/app-root/src/extlib/lib/perl5
+
 # Warning: Please note that this will pass all environment variables available within the
 # container to mod_perl by means of PerlPassEnv in the env.conf file
 if [ ! -f /opt/app-root/etc/httpd.d/env.conf ]; then

--- a/5.20/test/binpath/cpanfile
+++ b/5.20/test/binpath/cpanfile
@@ -1,0 +1,1 @@
+requires 'Net::IP';

--- a/5.20/test/binpath/index.pl
+++ b/5.20/test/binpath/index.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+print "Content-type: text/plain\n\n";
+my $output = `ipcount 2>&1`;
+if (!defined $output) {
+    die "No output from `ipcount' command";
+}
+print $output;

--- a/5.20/test/run
+++ b/5.20/test/run
@@ -32,7 +32,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/sample-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build "$@" file://${test_dir}/${test_name} ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 prepare() {
@@ -43,7 +43,7 @@ prepare() {
   # TODO: S2I build require the application is a valid 'GIT' repository, we
   # should remove this restriction in the future when a file:// is used.
   info "Build the test application image"
-  pushd ${test_dir}/sample-test-app >/dev/null
+  pushd ${test_dir}/${test_name} >/dev/null
   git init
   git config user.email "build@localhost" && git config user.name "builder"
   git add -A && git commit -m "Sample commit"
@@ -70,7 +70,7 @@ cleanup() {
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi -f ${IMAGE_NAME}-testapp
   fi
-  rm -rf ${test_dir}/sample-test-app/.git
+  rm -rf ${test_dir}/${test_name}/.git
 }
 
 check_result() {
@@ -127,25 +127,41 @@ test_scl_usage() {
   fi
 }
 
-test_connection() {
-  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+# Perform GET request to the application container.
+# First argument is request URI path.
+# Second argument is expected HTTP response code.
+# Third argument is PCRE regular expression that must match the response body.
+test_response() {
+  local uri_path="$1"
+  local expected_code="$2"
+  local body_regexp="$3"
+
+  local url="http://$(container_ip):${test_port}${uri_path}"
+  info "Testing the HTTP response for <${url}>"
   local max_attempts=10
   local sleep_time=1
   local attempt=1
   local result=1
   while [ $attempt -le $max_attempts ]; do
-    response_code=$(curl -s -w %{http_code} -o /dev/null http://$(container_ip):${test_port}/)
+    response=$(curl -s -w '%{http_code}' "${url}")
     status=$?
     if [ $status -eq 0 ]; then
-      if [ $response_code -eq 200 ]; then
+      response_code=$(printf '%s' "$response" | tail -c 3)
+      response_body=$(printf '%s' "$response" | head -c -3)
+      if [ "$response_code" -eq "$expected_code" ]; then
         result=0
       fi
+      printf '%s' "$response_body" | grep -qP -e "$body_regexp" || result=1;
       break
     fi
     attempt=$(( $attempt + 1 ))
     sleep $sleep_time
   done
   return $result
+}
+
+test_connection() {
+    test_response '/' 200 ''
 }
 
 test_application() {
@@ -163,31 +179,81 @@ test_application() {
   cleanup_test_app
 }
 
-cid_file=$(mktemp -u --suffix=.cid)
+# Build application, run it, perform test function, clean up.
+# First argument is directory name.
+# Second argument is function that expects running application. The function
+# must return (or terminate with) non-zero value to report an failure,
+# 0 otherwise.
+# Third argument is s2i --env argument value.
+do_test() {
+    test_name="$1"
+    test_function="$2"
+    test_environment="$3"
 
-# Since we built the candidate image locally, we don't want S2I attempt to pull
-# it from Docker hub
-s2i_args="--force-pull=false"
+    info "Starting tests for ${test_name}."
 
-prepare
-run_s2i_build
-check_result $?
+    cid_file=$(mktemp -u --suffix=.cid)
+    s2i_args="--force-pull=false"
 
-# Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-test_s2i_usage
-check_result $?
+    # Build and run the test application
+    prepare
+    run_s2i_build $s2i_args --env="$test_environment"
+    check_result $?
+    run_test_application &
+    wait_for_cid
 
-# Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-test_docker_run_usage
-check_result $?
+    # Perform user-supplied test function
+    $test_function;
+    check_result $?
 
-# Test application with default uid
-test_application
+    # Terminate the test application and clean up
+    cleanup_test_app
+    cleanup
+    info "All tests for the ${test_name} finished successfully."
+}
 
-# Test application with random uid
-CONTAINER_ARGS="-u 12345" test_application
 
-info "All tests for the sample-test-app finished successfully."
-cleanup
+# List of tests to execute:
+
+# This is original test that does more things like s2i API checks. Other tests
+# exectuted by do_test() will not repeat these checks.
+test_1() {
+    test_name='sample-test-app'
+    info "Starting tests for ${test_name}"
+
+    cid_file=$(mktemp -u --suffix=.cid)
+
+    # Since we built the candidate image locally, we don't want S2I attempt to pull
+    # it from Docker hub
+    s2i_args="--force-pull=false"
+
+    prepare
+    run_s2i_build $s2i_args
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
+    test_s2i_usage
+    check_result $?
+
+    # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
+    test_docker_run_usage
+    check_result $?
+
+    # Test application with default uid
+    test_application
+
+    # Test application with random uid
+    CONTAINER_ARGS="-u 12345" test_application
+
+    info "All tests for the ${test_name} finished successfully."
+    cleanup
+}
+test_1
+
+# Example how to use do_test()
+#test_2_function() {
+#    test_response '/' 200 'Usage'
+#}
+#do_test 'binpath' 'test_2_function'
 
 info "All tests finished successfully."

--- a/5.20/test/run
+++ b/5.20/test/run
@@ -250,10 +250,10 @@ test_1() {
 }
 test_1
 
-# Example how to use do_test()
-#test_2_function() {
-#    test_response '/' 200 'Usage'
-#}
-#do_test 'binpath' 'test_2_function'
+# Check scripts installed from CPAN are available to the application.
+test_2_function() {
+    test_response '/' 200 'Usage'
+}
+do_test 'binpath' 'test_2_function'
 
 info "All tests finished successfully."


### PR DESCRIPTION
It's not possible to execute scripts coming from CPAN. This is because the ~/extlib/bin is not in the PATH. Also ~/extlib/lib/perl5 must be added to Perl's include through environment variable in order to such script executed via kernel's execve() know where CPAN Perl modules  are installed.

This also augments the test/run script so that new tests can be added later.