### PR TITLE
Correct typos in tests

### DIFF
--- a/5.16/test/run
+++ b/5.16/test/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # The 'run' performs a simple test that verifies that S2I image.
-# The main focus here is to excersise the S2I scripts.
+# The main focus here is to exercise the S2I scripts.
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
@@ -181,10 +181,10 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-# Test application with default uid
+# Test application with default UID
 test_application
 
-# Test application with random uid
+# Test application with random UID
 CONTAINER_ARGS="-u 12345" test_application
 
 info "All tests for the sample-test-app finished successfully."

--- a/5.20/test/run
+++ b/5.20/test/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # The 'run' performs a simple test that verifies that S2I image.
-# The main focus here is to excersise the S2I scripts.
+# The main focus here is to exercise the S2I scripts.
 #
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
@@ -206,7 +206,7 @@ test_application() {
 # 0 otherwise.
 # Third argument is s2i --env argument value.
 # The test function have available container ID in $cid_file, container output
-# in ${tmp_dir}/out, countainer stderr in ${tmp_dir}/err.
+# in ${tmp_dir}/out, container stderr in ${tmp_dir}/err.
 do_test() {
     test_name="$1"
     test_function="$2"
@@ -241,7 +241,7 @@ do_test() {
 # List of tests to execute:
 
 # This is original test that does more things like s2i API checks. Other tests
-# exectuted by do_test() will not repeat these checks.
+# executed by do_test() will not repeat these checks.
 test_1() {
     test_name='sample-test-app'
     info "Starting tests for ${test_name}"
@@ -264,10 +264,10 @@ test_1() {
     test_docker_run_usage
     check_result $?
 
-    # Test application with default uid
+    # Test application with default UID
     test_application
 
-    # Test application with random uid
+    # Test application with random UID
     CONTAINER_ARGS="-u 12345" test_application
 
     info "All tests for the ${test_name} finished successfully."
@@ -289,7 +289,7 @@ do_test 'psgi' 'test_3_function'
 
 # Check variables can select a PSGI application and set URI path.
 test_4_function() {
-    test_response '/path' 200 '<title>Web::Paste::Simple'
+    test_response '/path' 200 '<title>Web::Paste::Simple' && \
     test_response '/cpanfile' 200 'requires'
 }
 do_test 'psgi-variables' 'test_4_function' 'PSGI_FILE=./application2.psgi,PSGI_URI_PATH=/path'


### PR DESCRIPTION
This patch set fixes misspellings in test comments and a bug in a test.