### PR TITLE
Log errors to stdout

### DIFF
--- a/5.16/contrib/etc/httpdconf.sed
+++ b/5.16/contrib/etc/httpdconf.sed
@@ -3,5 +3,5 @@ s/^User apache/User default/
 s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
-s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/2"%
+s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/1"%
 s%CustomLog "logs/access_log"%CustomLog "/proc/self/fd/1"%

--- a/5.20/contrib/etc/httpdconf.sed
+++ b/5.20/contrib/etc/httpdconf.sed
@@ -3,5 +3,5 @@ s/^User apache/User default/
 s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
-s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/2"%
+s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/1"%
 s%CustomLog "logs/access_log"%CustomLog "/proc/self/fd/1"%

--- a/5.20/test/run
+++ b/5.20/test/run
@@ -294,11 +294,13 @@ test_4_function() {
 }
 do_test 'psgi-variables' 'test_4_function' 'PSGI_FILE=./application2.psgi,PSGI_URI_PATH=/path'
 
-# Check httpd access_log flows to stdout, error_log to stderr.
+# Check httpd access_log flows to stdout, error_log to stdout.
+# TODO: send error_log to stderr after dropping support for broken
+# docker < 1.9.
 test_5_function() {
     test_response '/' 200 'Text in HTTP body' && \
     test_stdout '"GET /[^"]*" 200 ' && \
-    test_stderr 'Warning on stderr'
+    test_stdout 'Warning on stderr'
 }
 do_test 'warningonstderr' 'test_5_function'
 


### PR DESCRIPTION
This addresses issue #75 by log errors to standard output instead of storing them into a file. That was the main concern of the original issue #72.

It also preserves tests to make sure the errors are logged to standard output and to provide the useful test framework features.

Once support for docker 1.8 is dropped, reverting this tiny change will provide logging to error output.