### PR TITLE
Log to stdout via cat

### DIFF
--- a/5.16/contrib/etc/httpdconf.sed
+++ b/5.16/contrib/etc/httpdconf.sed
@@ -3,7 +3,5 @@ s/^User apache/User default/
 s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
-#s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/1"%
-#s%CustomLog "logs/access_log"%CustomLog "/proc/self/fd/1"%
-s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
+s%^ErrorLog "logs/error_log"%ErrorLog "|/usr/bin/cat"%
 s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%

--- a/5.20/contrib/etc/httpdconf.sed
+++ b/5.20/contrib/etc/httpdconf.sed
@@ -3,7 +3,5 @@ s/^User apache/User default/
 s/^Group apache/Group root/
 s%^DocumentRoot "/opt/rh/httpd24/root/var/www/html"%DocumentRoot "/opt/app-root/src"%
 s%^<Directory "/opt/rh/httpd24/root/var/html"%<Directory "/opt/app-root/src"%
-#s%^ErrorLog "logs/error_log"%ErrorLog "/proc/self/fd/1"%
-#s%CustomLog "logs/access_log"%CustomLog "/proc/self/fd/1"%
-s%^ErrorLog "logs/error_log"%ErrorLog "/tmp/error_log"%
+s%^ErrorLog "logs/error_log"%ErrorLog "|/usr/bin/cat"%
 s%CustomLog "logs/access_log"%CustomLog "|/usr/bin/cat"%

--- a/5.20/test/run
+++ b/5.20/test/run
@@ -297,11 +297,11 @@ do_test 'psgi-variables' 'test_4_function' 'PSGI_FILE=./application2.psgi,PSGI_U
 # Check httpd access_log flows to stdout, error_log to stdout.
 # TODO: send error_log to stderr after dropping support for broken
 # docker < 1.9.
-#test_5_function() {
-#    test_response '/' 200 'Text in HTTP body' && \
-#    test_stdout '"GET /[^"]*" 200 ' && \
-#    test_stdout 'Warning on stderr'
-#}
-#do_test 'warningonstderr' 'test_5_function'
+test_5_function() {
+    test_response '/' 200 'Text in HTTP body' && \
+    test_stdout '"GET /[^"]*" 200 ' && \
+    test_stdout 'Warning on stderr'
+}
+do_test 'warningonstderr' 'test_5_function'
 
 info "All tests finished successfully."


### PR DESCRIPTION
Docker 1.8.2 cannot open /proc/self/fd files. The only way how to
write to standard output is to write to already opened descriptor.

In order to obtain httpd errors from docker client, we send error to
standard output too.

I've checked it with 1.8.2 and 1.9.1 this time.

<https://github.com/openshift/sti-perl/pull/78>